### PR TITLE
feat: add long-press delete playlist from library

### DIFF
--- a/lib/ui/screens/Library/library_controller.dart
+++ b/lib/ui/screens/Library/library_controller.dart
@@ -554,14 +554,25 @@ class LibraryPlaylistsController extends GetxController
   Future<void> deletePlaylist(Playlist playlist) async {
     if (reservedCollectionIds.contains(playlist.playlistId)) return;
 
+    if (playlist.isPipedPlaylist) {
+      await Get.find<PipedServices>().deletePlaylist(playlist.playlistId);
+      await syncPipedPlaylist();
+      return;
+    }
+
     final box = await SqliteStore.openBox("LibraryPlaylists");
     await box.delete(playlist.playlistId);
 
-    if (!playlist.isPipedPlaylist) {
-      await SqliteStore.deleteBoxFromDisk(sanitizeBoxName(playlist.playlistId));
-    }
+    final songsBox = await SqliteStore.openBox(sanitizeBoxName(playlist.playlistId));
+    await songsBox.deleteFromDisk();
 
     refreshLib();
+    Get.find<SyncService>().triggerPush();
+
+    if (!playlist.isCloudPlaylist) {
+      final plstbox = await SqliteStore.openBox(sanitizeBoxName(playlist.playlistId));
+      await plstbox.deleteFromDisk();
+    }
   }
 
   @override

--- a/lib/ui/screens/Library/library_controller.dart
+++ b/lib/ui/screens/Library/library_controller.dart
@@ -551,6 +551,19 @@ class LibraryPlaylistsController extends GetxController
     tempListContainer.clear();
   }
 
+  Future<void> deletePlaylist(Playlist playlist) async {
+    if (reservedCollectionIds.contains(playlist.playlistId)) return;
+
+    final box = await SqliteStore.openBox("LibraryPlaylists");
+    await box.delete(playlist.playlistId);
+
+    if (!playlist.isPipedPlaylist) {
+      await SqliteStore.deleteBoxFromDisk(sanitizeBoxName(playlist.playlistId));
+    }
+
+    refreshLib();
+  }
+
   @override
   void dispose() {
     textInputController.dispose();

--- a/lib/ui/widgets/content_list_widget_item.dart
+++ b/lib/ui/widgets/content_list_widget_item.dart
@@ -12,6 +12,13 @@ import 'package:harmonymusic/models/playling_from.dart';
 import 'package:harmonymusic/models/media_item_builder.dart';
 import 'package:harmonymusic/services/music/music_service.dart';
 import 'package:harmonymusic/ui/player/player_controller.dart';
+import 'package:harmonymusic/ui/screens/Library/library_controller.dart';
+import 'package:harmonymusic/generated/l10n.dart';
+import 'package:harmonymusic/models/playlist.dart';
+
+import 'package:harmonymusic/ui/theme/app_spacing.dart';
+import 'common_dialog_widget.dart';
+import 'custom_button.dart';
 
 class ContentListItem extends StatelessWidget {
   final double? width;
@@ -74,6 +81,51 @@ class ContentListItem extends StatelessWidget {
             id: ScreenNavigationSetup.id,
             arguments: [content, content.playlistId]);
       },
+      onLongPress: (isLibraryItem &&
+              content is Playlist &&
+              !LibraryPlaylistsController.reservedCollectionIds
+                  .contains(content.playlistId))
+          ? () {
+              Get.dialog(
+                CommonDialog(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        vertical: AppSpacing.lg, horizontal: AppSpacing.xl),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          S.current.removePlaylist,
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
+                        const SizedBox(height: AppSpacing.md),
+                        Text(
+                          "${S.current.delete} ${content.title}?",
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: AppSpacing.xl),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: [
+                            const CancelButton(),
+                            ProceedButton(
+                              buttonText: S.current.delete,
+                              onPressed: () {
+                                Get.find<LibraryPlaylistsController>()
+                                    .deletePlaylist(content);
+                                Get.back();
+                              },
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            }
+          : null,
       child: Container(
         width: finalWidth,
         height: finalHeight,


### PR DESCRIPTION
### Problem
Some playlists imported from other music apps could appear in the Library but fail to open because of malformed or unsupported import data, leaving users with no way to delete them.

### Solution
Added the ability to delete playlists directly from the Library via a long-press action with a confirmation dialog.

### Changes
* Added `deletePlaylist()` to handle playlist deletion.
* Added a long-press action on Library playlist items to trigger a confirmation dialog before deletion.
* Prevented deletion of reserved/system playlists.
